### PR TITLE
[BUGFIX] Provide fallback value for colPos

### DIFF
--- a/Classes/Hooks/DatamapDataHandlerHook.php
+++ b/Classes/Hooks/DatamapDataHandlerHook.php
@@ -50,7 +50,7 @@ class DatamapDataHandlerHook extends AbstractDataHandlerHook
                 $pageId = (int)$previousRecord['pid'];
                 $incomingFieldArray['pid'] = $pageId;
             }
-            $colPos = (int)$incomingFieldArray['colPos'];
+            $colPos = (int)($incomingFieldArray['colPos'] ?? 0);
 
             $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
             $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos, $id);


### PR DESCRIPTION
This prevents a PHP warning whenever colPos isn't part of the incomingFieldArray (e.g. due to being hidden from the users)